### PR TITLE
FPO-184: Adds reference to the status page

### DIFF
--- a/source/partials/_intro.html.md
+++ b/source/partials/_intro.html.md
@@ -2,5 +2,8 @@ This is the technical documentation for the Online Trade Tariff team in [HM Reve
 
 For technical documentation applicable to OTT APIs, see [API docs][API].
 
+To review the current status of the applications managed by this team please see [status] page
+
 [HMRC]: https://www.gov.uk/government/organisations/hm-revenue-customs
 [API]: https://api.trade-tariff.service.gov.uk/
+[status]: https://status.trade-tariff.service.gov.uk


### PR DESCRIPTION
### Jira link

FPO-184

### What?

I have added/removed/altered:

- [x] Added reference to the status page

### Why?

I am doing this because:

- This is required to communicate its availability to new and existing devs
