### PR TITLE
FPO-194: Add docker-compose + LocalStack (www.localstack.cloud)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,69 @@
+version: "2"
+services:
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - 127.0.0.1:6379:6379
+    volumes:
+      - dev-env-redis-volume:/data
+  hmrc-postgres:
+    container_name: postgres
+    image: postgres:13
+    environment:
+      - PGDATA=/var/lib/postgresql/data/pgdata
+      - POSTGRES_USER=${USER}
+      - POSTGRES_PASSWORD=
+      - LANG=C.UTF-8
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    ports:
+      - 127.0.0.1:5432:5432
+    volumes:
+       - hmrc-postgres13:/var/lib/postgresql/data
+  hmrc-opensearch:
+    container_name: hmrc-opensearch
+    image: opensearchproject/opensearch:2
+    ports:
+      - 127.0.0.1:9200:9200
+      - 127.0.0.1:9300:9300
+    environment:
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - "OPENSEARCH_JAVA_OPTS=-Xms500m -Xmx500m"
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - plugins.security.disabled=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      interval: 60s
+      retries: 10
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+    volumes:
+      - hmrc-os:/usr/share/opensearch/data
+      - ./config/opensearch/synonyms_all.txt:/usr/share/opensearch/config/synonyms_all.txt:z
+      - ./config/opensearch/stemming_exclusions_all.txt:/usr/share/opensearch/config/stemming_exclusions_all.txt:z
+  
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - 4566:4566           # LocalStack edge port
+      - 4510-4559:4510-4559 # maps various AWS services ports
+    volumes:
+      # Initialization Hook (see https://docs.localstack.cloud/references/init-hooks/)
+      - ./localstack-setup.sh:/etc/localstack/init/ready.d/script.sh
+volumes:
+  dev-env-redis-volume:
+    driver: local
+  postgres:
+    driver: local
+  hmrc-postgres:
+    driver: local
+  hmrc-postgres13:
+    driver: local
+  hmrc-os:
+    driver: local

--- a/localstack-setup.sh
+++ b/localstack-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+echo "Initializing localstack s3"
+
+
+echo "Creating dynamodb tables..."
+aws dynamodb create-table \
+    --table-name CustomerApiKeys \
+    --attribute-definitions \
+        AttributeName=CustomerApiKeyId,AttributeType=S \
+        AttributeName=FpoId,AttributeType=S \
+    --key-schema \
+        AttributeName=CustomerApiKeyId,KeyType=HASH \
+        AttributeName=FpoId,KeyType=RANGE \
+    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+
+echo "Creating API Gateway..."
+# TODO: Create API Gateway

--- a/localstack-setup.sh
+++ b/localstack-setup.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 echo "Initializing localstack s3"
 
+# You must specify a region. You can also configure your region by running "aws configure".
 
 echo "Creating dynamodb tables..."
-aws dynamodb create-table \
+aws --endpoint-url=http://localhost:4566  dynamodb create-table \
+    --region eu-west-2 \
     --table-name CustomerApiKeys \
     --attribute-definitions \
         AttributeName=CustomerApiKeyId,AttributeType=S \


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/FPO-194

### What?
Recreated `docker-compose.yml` from the Readme
Added localstack in the `services` section in the docker-compose.yml
Added localstack-setup.sh to initialise the local AWS services that we need
  DONE:
  -[x] dynamodb 
  
  TODO: 
  -[] API Gatway
  -[] other?!?

### Why?
So we don't need to setup AWS services to manually or run integration-test