### PR TITLE
OTT_402: Document installing ruby

### DIFF
--- a/source/manual/brakeman.html.md
+++ b/source/manual/brakeman.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Brakeman
 section: Testing
 layout: manual_layout

--- a/source/manual/codeql.html.md
+++ b/source/manual/codeql.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: CodeQL
 section: Testing
 layout: manual_layout

--- a/source/manual/configure-linting.html.md
+++ b/source/manual/configure-linting.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Configure linting
 section: Applications
 type: learn

--- a/source/manual/content-security-policy.html.md
+++ b/source/manual/content-security-policy.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: 'Content Security Policy on GOV.UK'
 section: Security
 layout: manual_layout

--- a/source/manual/conventions-for-rails-applications.html.md
+++ b/source/manual/conventions-for-rails-applications.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Conventions for Rails applications
 section: Applications
 type: learn

--- a/source/manual/deploy-static.html.md
+++ b/source/manual/deploy-static.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Deploy Static
 section: Deployment
 layout: manual_layout

--- a/source/manual/deployments.html.md
+++ b/source/manual/deployments.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Deployments
 section: Deployment
 layout: manual_layout

--- a/source/manual/development-pipeline.html.md
+++ b/source/manual/development-pipeline.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: The development and deployment pipeline
 parent: "/manual.html"
 layout: manual_layout
@@ -76,7 +76,7 @@ It is important to ensure people are aware of a code freeze
 
 Let people know on Slack
 
-> Send a message to #govuk-developers on slack with the @channel
+> Send a message to #ott-core on slack with the @channel
 > prefix (to ensure people who are offline are notified) and email
 > <govuk-tech-members@digital.cabinet-office.gov.uk>. Your message
 > should include the repo you are freezing, the reason why, and the

--- a/source/manual/docs-style-guide.html.md
+++ b/source/manual/docs-style-guide.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Documentation style guide
 section: Documentation
 layout: manual_layout

--- a/source/manual/get-started.html.md
+++ b/source/manual/get-started.html.md
@@ -206,7 +206,17 @@ While rebasing is generally acceptable during the development process, please en
 
 For more information on which repositories depend on merge commits, please refer to [this][generate-release-notes] script.
 
+## 12. A note on installing dependencies
+
+We use [asdf][asdf] to manage versions of programming languages and tools. This allows us to have multiple versions of the same tool installed on our machines.
+
+Our main languages are Ruby and Node.js, so you will need to install these with asdf.
+
+To keep up-to-date with ruby installations in each project you can follow the [ruby installation guide][ruby-installation].
+
 [generate-release-notes]: https://github.com/trade-tariff/trade-tariff-tools/blob/main/bin/generate_release_notes.sh
 [regression-chat]: https://future-borders.slack.com/archives/C02T8JXUYE9
 [developer-chat]: https://future-borders.slack.com/archives/C01DXUP15M5
 [infrastructure-chat]: https://future-borders.slack.com/archives/C042HGJBHK8
+[asdf]: https://asdf-vm.com/
+[ruby-installation]: /manual/ruby.html

--- a/source/manual/how-to-escalate-to-AWS-support.html.md
+++ b/source/manual/how-to-escalate-to-AWS-support.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: How to raise a support ticket with AWS
 
 section: AWS

--- a/source/manual/keeping-software-current.html.md
+++ b/source/manual/keeping-software-current.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Policy on keeping software current
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/ruby.html.md
+++ b/source/manual/ruby.html.md
@@ -1,0 +1,77 @@
+---
+owner_slack: "#ott-core"
+title: Install ruby
+section: Applications
+layout: manual_layout
+parent: "/manual.html"
+---
+
+> We use `asdf` to manage multiple runtime versions. This guide will show you how to install `ruby` with `asdf`.
+
+## Prerequisites
+
+- Mac
+- [Homebrew][homebrew]
+- curl
+- git
+
+## Steps
+
+- Install `asdf` with homebrew
+- Install `ruby` with `asdf`
+- Enable a global version of `ruby` with `asdf`
+- Check your ruby version
+
+### Install `asdf` with homebrew
+
+```sh
+brew install asdf
+echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+```
+
+### Install `ruby` with `asdf`
+
+```sh
+# Enable the ruby plugin in asdf
+asdf plugin add ruby
+# Find a ruby version you want
+asdf list-all ruby
+# Install the version you want
+asdf install ruby 3.0.2
+```
+
+### Enable a global version of `ruby` with `asdf`
+
+```sh
+# Enable a global version of ruby
+asdf global ruby 3.0.2
+```
+
+### Check your ruby version
+
+```sh
+ruby --version
+```
+
+## Project-specific ruby versions
+
+`asdf` offers support for a local file in a specific project to specify the version of ruby to use.
+
+This diminishes the chance of differences between your locally used version of ruby and the version installed
+in other environments from causing issues.
+
+This is all configured with `.tool-versions` in the root of each project repoistory
+
+For example, to specify the version of ruby to use in a project, create a `.tool-versions` file in the root of the project repository with the following content:
+
+```sh
+asdf local ruby 3.0.2
+```
+
+## Project-specific updates to ruby
+
+If you need to update the version of ruby in a project, update the `.tool-versions` file in the root of the project repository with the new version of ruby you want to use.
+
+Everyone that uses `asdf` can then just run `asdf install` in the project repository to install the new version of ruby.
+
+[homebrew]: https://brew.sh/

--- a/source/manual/running-rake-tasks.html.md
+++ b/source/manual/running-rake-tasks.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Run a rake task
 section: Deployment
 layout: manual_layout
@@ -16,5 +16,3 @@ For example:
 ```sh
 kubectl exec deploy/publishing-api -- rake 'represent_downstream:published_between[2018-12-17T01:02:30, 2018-12-18T10:20:30]'
 ```
-
-The output of the command will be streamed to your terminal.

--- a/source/manual/sentry.html.md
+++ b/source/manual/sentry.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Sentry
 parent: "/manual.html"
 layout: manual_layout

--- a/source/manual/setting-up-new-rails-app.html.md
+++ b/source/manual/setting-up-new-rails-app.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: Set up a new Rails application
 section: Applications
 layout: manual_layout

--- a/source/manual/testing.html.md
+++ b/source/manual/testing.html.md
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#govuk-developers"
+owner_slack: "#ott-core"
 title: 'How we test GOV.UK'
 section: Testing
 type: learn


### PR DESCRIPTION
### Jira link

OTT-402

### What?

I have added/removed/altered:

- [x] Adjust standard slack channel for most manuals
- [x] Adds ruby installation guide

### Why?

I am doing this because:

- This was causing some confusion for newer devs and gives us a single place to define how we do these things
